### PR TITLE
Prevent access to Android components if they do not need external communication

### DIFF
--- a/camera/MultiCameraApplication/AndroidManifest.xml
+++ b/camera/MultiCameraApplication/AndroidManifest.xml
@@ -20,6 +20,7 @@
 	android:theme="@style/AppTheme" >
 
         <activity android:name=".CtsCameraIntentsActivity"
+                  android:exported="false"
                   android:excludeFromRecents="true"
                   android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>


### PR DESCRIPTION
Prevent access to Android components if they do not need external communication