### PR TITLE
Application shows dialog when USB camera hot plug

### DIFF
--- a/camera/MultiCameraApplication/res/values/strings.xml
+++ b/camera/MultiCameraApplication/res/values/strings.xml
@@ -141,6 +141,7 @@
     <string name="unknown">Unknown</string>
 
     <string name="details">Details</string>
+    <string name="usb_change">USB hot plug detected</string>
     <string name="close">Close</string>
 
     <!-- The height and width of a photo. -->


### PR DESCRIPTION
When application opened and user plug\unplug USB
camera then application start operation on wrong
device id's because when hot plug happends device
id's gets realign because of this many stability
issues observed on USB hot plug

Solution : Whenever USB hot plug detected application
will show dialog to close application. Closing and opening
application will make application works on right device
nodes.

Tracked-On : OAM-91443

Signed-off-by: Shiva Kumara  <shiva.kumara.rudrappa@intel.com>
Signed-off-by: kbillore <kaushal.billore@intel.com>