### PR TITLE
When application opened and user plug\unplug USB

### DIFF
--- a/camera/MultiCameraApplication/java/com/intel/multicamera/SingleCameraActivity.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/SingleCameraActivity.java
@@ -18,6 +18,7 @@
 package com.intel.multicamera;
 
 import android.Manifest;
+import android.app.Dialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -32,6 +33,7 @@ import android.os.Bundle;
 import android.os.SystemClock;
 import android.util.Log;
 import android.view.View;
+import android.view.Window;
 import android.view.WindowManager;
 import android.widget.ImageButton;
 import android.widget.ImageView;
@@ -50,7 +52,7 @@ import static com.intel.multicamera.MultiViewActivity.updateStorageSpace;
 public class SingleCameraActivity extends AppCompatActivity {
     private static final String TAG = "SingleCameraActivity";
     private boolean mHasCriticalPermissions;
-
+    private int isDialogShown;
     private int numOfCameras;
     private AutoFitTextureView mCamera_BackView, mCamera_FrontView;
 
@@ -76,7 +78,7 @@ public class SingleCameraActivity extends AppCompatActivity {
         if (actionBar != null) {
             actionBar.setHomeButtonEnabled(true);
         }
-
+        isDialogShown = 0;
         setContentView(R.layout.activity_full_screen);
 
         mIsRecordingVideo = false;
@@ -94,6 +96,54 @@ public class SingleCameraActivity extends AppCompatActivity {
 
         checkPermissions();
         OpenCamera();
+        try {
+            IntentFilter filter = new IntentFilter();
+            filter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
+            filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
+
+            // BroadcastReceiver when insert/remove the device USB plug into/from a USB port
+            mUsbReceiver = new BroadcastReceiver() {
+                public void onReceive(Context context, Intent intent) {
+                    String action = intent.getAction();
+                    if (UsbManager.ACTION_USB_DEVICE_ATTACHED.equals(action)) {
+                        System.out.println(TAG + "BroadcastReceiver USB Connected");
+                        if (isDialogShown == 0) {
+                            Dialog detailDialog = USBChangeDialog.create(SingleCameraActivity.this);
+                            detailDialog.setCancelable(false);
+                            detailDialog.setCanceledOnTouchOutside(false);
+                            detailDialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+                            detailDialog.show();
+                            isDialogShown = 1;
+                            mCameraSwitch.setVisibility(View.GONE);
+                            mCameraRecord.setVisibility(View.GONE);
+                            mCameraPicture.setVisibility(View.GONE);
+                            mCameraSplit.setVisibility(View.GONE);
+                        }
+
+                    } else if (UsbManager.ACTION_USB_DEVICE_DETACHED.equals(action)) {
+                        System.out.println(TAG + "BroadcastReceiver USB Disconnected");
+                        if (isDialogShown == 0) {
+                            Dialog detailDialog = USBChangeDialog.create(SingleCameraActivity.this);
+                            detailDialog.setCancelable(false);
+                            detailDialog.setCanceledOnTouchOutside(false);
+                            detailDialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+                            detailDialog.show();
+                            isDialogShown = 1;
+                            mCameraSwitch.setVisibility(View.GONE);
+                            mCameraRecord.setVisibility(View.GONE);
+                            mCameraPicture.setVisibility(View.GONE);
+                            mCameraSplit.setVisibility(View.GONE);
+                        }
+                    }
+                }
+            };
+            registerReceiver(mUsbReceiver , filter);
+        } catch (Exception e) {
+            //there is race condition when camera connection app is trying to open during that
+            // time is camera is disconnect suddently then its trying to access non exist device
+            //nodes hence crash is observed
+            System.out.println(TAG + " Exception occured during USB attach and detach");
+        }
 
         mCameraSwitch.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/camera/MultiCameraApplication/java/com/intel/multicamera/USBChangeDialog.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/USBChangeDialog.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.multicamera;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.text.format.Formatter;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.ListView;
+import android.widget.TextView;
+
+public class USBChangeDialog {
+    /**
+     * Creates a dialog to show USB hot plug message
+     *
+     * @param context the Android context.
+     * @return A dialog that can be made visible to show the media details.
+     */
+    public static Dialog create(final Context context) {
+        ListView detailsList =
+                (ListView)LayoutInflater.from(context).inflate(R.layout.details_list, null, false);
+        detailsList.setAdapter(new DetailsAdapter(context));
+
+        final AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        return builder.setTitle(R.string.usb_change)
+                .setView(detailsList)
+                .setPositiveButton(R.string.close,
+                                   new DialogInterface.OnClickListener() {
+                                       @Override
+                                       public void onClick(DialogInterface dialog,
+                                                           int whichButton) {
+                                           Activity activity = (Activity) context;
+                                           activity.finish();
+                                       }
+                                   })
+                .create();
+    }
+
+    /**
+     * An adapter for feeding a details list view.
+     */
+    private static class DetailsAdapter extends BaseAdapter {
+        private final Context mContext;
+
+        public DetailsAdapter(Context context) {
+            mContext = context;
+        }
+
+        @Override
+        public boolean areAllItemsEnabled() {
+            return false;
+        }
+
+        @Override
+        public boolean isEnabled(int position) {
+            return false;
+        }
+
+        @Override
+        public int getCount() {
+            return 0;
+        }
+
+        @Override
+        public Object getItem(int position) {
+            return null;
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            TextView tv;
+            if (convertView == null) {
+                tv = (TextView)LayoutInflater.from(mContext).inflate(R.layout.details, parent,
+                                                                     false);
+            } else {
+                tv = (TextView)convertView;
+            }
+            return tv;
+        }
+    }
+}

--- a/camera/MultiCameraApplication/res/values/strings.xml
+++ b/camera/MultiCameraApplication/res/values/strings.xml
@@ -141,6 +141,7 @@
     <string name="unknown">Unknown</string>
 
     <string name="details">Details</string>
+    <string name="usb_change">USB hot plug detected</string>
     <string name="close">Close</string>
 
     <!-- The height and width of a photo. -->


### PR DESCRIPTION
camera then application start operation on wrong
device id's because when hot plug happends device
id's gets realign because of this many stability
issues observed on USB hot plug

Solution : Whenever USB hot plug detected application
will show dialog to close application. Closing and opening
application will make application works on right device
nodes.

Tracked-On : OAM-91545

Signed-off-by: Shiva Kumara  <shiva.kumara.rudrappa@intel.com>
Signed-off-by: kbillore <kaushal.billore@intel.com>