### PR TITLE
different video resolution support

### DIFF
--- a/camera/MultiCameraApplication/java/com/intel/multicamera/FullScreenActivity.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/FullScreenActivity.java
@@ -402,7 +402,7 @@ public class FullScreenActivity extends AppCompatActivity {
         Data[0] = "FrontCamera";
         Data[1] = CameraIds[1];
         Data[2] = "capture_list_1";
-        Data[3] = "video_list_1";
+        Data[3] = "video_list";
         Data[4] = "pref_resolution_1";
 
         mCameraFront = new CameraBase(this, mCamera_FrontView, null, mRecordingTimeView,


### PR DESCRIPTION
reading video recording capabality from media profiler and
matching with USB HW capability based on camera ID is not
working and it needed more changes in flow.

Solution: As we are supporting same  USB camera passing similar
set of video resolution list for both front and back camera.

Tracked-On : OAM-91868

Signed-off-by: Shiva Kumara shiva.kumara.rudrappa@intel.com
Signed-off-by: kbillore <kaushal.billore@intel.com>