### PR TITLE
video resolution change is not persistent

### DIFF
--- a/camera/MultiCameraApplication/java/com/intel/multicamera/CameraBase.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/CameraBase.java
@@ -356,7 +356,6 @@ public class CameraBase  {
     private void ResetResolutionSettings() {
         SharedPreferences.Editor edit = settings.edit();
         edit.remove(Capture_Key);
-        edit.remove(Video_key);
         edit.apply();
     }
 


### PR DESCRIPTION
change video resolution and switch between front and
back camera then record. recorded video is falling
back to default resolution.when switching the camera,
camera close will be called and as part of camera
close it will delete the video key entry.

Solution: not remove the video key entry as part of
camera close. with this only one setting exist for all
camera

Tracked-On: OAM-92011
Signed-off-by: Shiva Kumara shiva.kumara.rudrappa@intel.com
Signed-off-by: kbillore <kaushal.billore@intel.com>