### PR TITLE
[Work Around] Fail to play recorded video from multi camera app

### DIFF
--- a/camera/MultiCameraApplication/java/com/intel/multicamera/FullScreenActivity.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/FullScreenActivity.java
@@ -36,6 +36,7 @@ import android.hardware.usb.UsbManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.SystemClock;
+import android.os.StrictMode;
 import android.util.Log;
 import android.view.View;
 import android.view.Window;
@@ -80,6 +81,9 @@ public class FullScreenActivity extends AppCompatActivity {
 
         getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
+
+        StrictMode.VmPolicy.Builder builder = new StrictMode.VmPolicy.Builder();
+        StrictMode.setVmPolicy(builder.build());
 
         isDialogShown = 0;
         ActionBar actionBar = getSupportActionBar();

--- a/camera/MultiCameraApplication/java/com/intel/multicamera/PhotoPreview.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/PhotoPreview.java
@@ -159,7 +159,7 @@ public class PhotoPreview {
             playButton.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    Utils.playVideo(mActivity, ic_camera.getCurrentUri(), TAG);
+                    Utils.playVideo(mActivity, videoUri, TAG);
                 }
             });
 


### PR DESCRIPTION
playing video from multi camera app is getting failed
because with android 11 and target sdk version above 29
sharing Uri path to external app is not allowed.

Solution : As work around solution we are changing the vm policy
to allow this application to share URI paths

Tracked-On: OAM-96187
Signed-off-by: shiva kumara R <shiva.kumara.rudrappa@intel.com>