### PR TITLE
revert camera flicker workaround patch

### DIFF
--- a/camera/MultiCameraApplication/java/com/intel/multicamera/MultiCamera.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/MultiCamera.java
@@ -37,7 +37,7 @@ public class MultiCamera {
     MultiCamera() {
         mWhichCamera = 0;
         mIsCameraOrSurveillance = 0;
-        mOpenCameraId = 0;
+        mOpenCameraId = -1;
     }
     public static MultiCamera getInstance() {
         if (ic_instance == null) {

--- a/camera/MultiCameraApplication/java/com/intel/multicamera/MultiViewActivity.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/MultiViewActivity.java
@@ -331,7 +331,6 @@ public class MultiViewActivity extends AppCompatActivity {
                  ic_camera.setOpenCameraId(0);
                  closeCamera();
                  ic_camera.setIsCameraOrSurveillance(0);
-                 unregisterReceiver(mUsbReceiver);
                  Intent intent = new Intent(MultiViewActivity.this, SingleCameraActivity.class);
                  intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK|Intent.FLAG_ACTIVITY_CLEAR_TOP);
                  startActivity(intent);
@@ -377,7 +376,6 @@ public class MultiViewActivity extends AppCompatActivity {
                 ic_camera.setOpenCameraId(1);
                 closeCamera();
                 ic_camera.setIsCameraOrSurveillance(0);
-                unregisterReceiver(mUsbReceiver);
                 Intent intent = new Intent(MultiViewActivity.this, SingleCameraActivity.class);
                 intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK|Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 startActivity(intent);
@@ -423,7 +421,6 @@ public class MultiViewActivity extends AppCompatActivity {
             public void onClick(View v) {
                 ic_camera.setOpenCameraId(2);
                 closeCamera();
-                unregisterReceiver(mUsbReceiver);
                 Intent intent = new Intent(MultiViewActivity.this, SingleCameraActivity.class);
                 intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK|Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 startActivity(intent);
@@ -471,7 +468,6 @@ public class MultiViewActivity extends AppCompatActivity {
             public void onClick(View v) {
                 ic_camera.setOpenCameraId(3);
                 closeCamera();
-                unregisterReceiver(mUsbReceiver);
                 Intent intent = new Intent(MultiViewActivity.this, SingleCameraActivity.class);
                 intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK|Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 startActivity(intent);
@@ -1285,7 +1281,7 @@ public class MultiViewActivity extends AppCompatActivity {
         }
 
         closeCamera();
-        unregisterReceiver(mUsbReceiver);
+
         Intent intent = new Intent(MultiViewActivity.this, SingleCameraActivity.class);
         intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK|Intent.FLAG_ACTIVITY_CLEAR_TOP);
         startActivity(intent);

--- a/camera/MultiCameraApplication/java/com/intel/multicamera/SingleCameraActivity.java
+++ b/camera/MultiCameraApplication/java/com/intel/multicamera/SingleCameraActivity.java
@@ -171,23 +171,14 @@ public class SingleCameraActivity extends AppCompatActivity {
                 MultiCamera ic_camera = MultiCamera.getInstance();
                 if (ic_camera.getWhichCamera() == 0) {
                     ic_camera.setOpenCameraId(1);
-
-                    Log.i(TAG,"Opened front camera");
-                    closeCamera();
-                    unregisterReceiver(mUsbReceiver);
-                    startActivity(new Intent(getApplicationContext(), FullScreenActivity.class));
+                    OpenCamera();
                     ic_camera.setWhichCamera(1);
-                    finishAffinity();
-
+                    Log.i(TAG,"Opened front camera");
                 }
                 else {
                     ic_camera.setOpenCameraId(0);
-                    closeCamera();
-                    unregisterReceiver(mUsbReceiver);
-                    startActivity(new Intent(getApplicationContext(), FullScreenActivity.class));
+                    OpenCamera();
                     ic_camera.setWhichCamera(0);
-                    finishAffinity();
-
                     Log.i(TAG,"Opened back camera");
                 }
             }
@@ -198,7 +189,6 @@ public class SingleCameraActivity extends AppCompatActivity {
             public void onClick(View v) {
                 MultiCamera ic_camera = MultiCamera.getInstance();
                 ic_camera.setIsCameraOrSurveillance(1);
-                unregisterReceiver(mUsbReceiver);
                 Intent intent = new Intent(SingleCameraActivity.this, MultiViewActivity.class);
                 intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK|Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 startActivity(intent);


### PR DESCRIPTION
During camera switching we had observed preview start
flicker sometimes, hence provied solution by recreate
surface during camera switching. With recent mesa library
upgrade no such work around patch is required.

Solution : reverting workaround patch

Tracked-On: OAM-96186

Signed-off-by: shivasku82 <shiva.kumara.rudrappa@intel.com>